### PR TITLE
feat(cli): Add cat_xlsx command with usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # rust-cli-tools
-My CLI tools written by Rust
+
+## cat_xlsx Usage:
+
+```shell
+Usage: cat_xlsx <XLSX_FILE>
+
+Arguments:
+  <XLSX_FILE>  Path to the xlsx file
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```

--- a/cat_xlsx/Cargo.toml
+++ b/cat_xlsx/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-calamine = "0.21.0"
+clap = { version = "4.1", features = ["derive"] }
+calamine = "0.26.1"

--- a/cat_xlsx/src/main.rs
+++ b/cat_xlsx/src/main.rs
@@ -17,7 +17,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let path = args.xlsx_file;
     // Check if the file exists
     if !path.exists() {
-        eprintln!("Error: File '{}' does not exist.", path.display());
+    // Validate file extension
+    if !path.extension().map_or(false, |ext| ext.eq_ignore_ascii_case("xlsx")) {
+        eprintln!("Error: File must have .xlsx extension");
         std::process::exit(1);
     }
 

--- a/cat_xlsx/src/main.rs
+++ b/cat_xlsx/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Validate file extension
     if !path
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("xlsx"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("xlsx"))
     {
         eprintln!("Error: File must have .xlsx extension");
         std::process::exit(1);

--- a/cat_xlsx/src/main.rs
+++ b/cat_xlsx/src/main.rs
@@ -10,6 +10,9 @@ struct Args {
     xlsx_file: PathBuf,
 }
 
+/// Reads and displays the contents of an Excel (.xlsx) file.
+/// Iterates through all worksheets and prints their contents in a tab-separated format.
+/// Each worksheet is clearly delimited and labeled.
 fn main() -> Result<(), Box<dyn Error>> {
     // Get the path to the xlsx file from command-line arguments
     let args = Args::parse();

--- a/cat_xlsx/src/main.rs
+++ b/cat_xlsx/src/main.rs
@@ -1,15 +1,25 @@
-use calamine::{open_workbook_auto, DataType, Reader};
-use std::env;
+use calamine::{open_workbook_auto, Data, Reader};
+use clap::Parser;
 use std::error::Error;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the xlsx file
+    xlsx_file: PathBuf,
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Get the path to the xlsx file from command-line arguments
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        eprintln!("Usage: {} <file.xlsx>", args[0]);
+    let args = Args::parse();
+
+    let path = args.xlsx_file;
+    // Check if the file exists
+    if !path.exists() {
+        eprintln!("Error: File '{}' does not exist.", path.display());
         std::process::exit(1);
     }
-    let path = &args[1];
 
     // Open the workbook (auto-detects the format)
     let mut workbook = open_workbook_auto(path)?;
@@ -17,18 +27,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Iterate over the worksheets
     let sheet_names = workbook.sheet_names().to_owned();
     for sheet_name in sheet_names {
-        if let Some(Ok(range)) = workbook.worksheet_range(&sheet_name) {
+        if let Ok(range) = workbook.worksheet_range(&sheet_name) {
             println!("Sheet: {}", sheet_name);
             for row in range.rows() {
                 for cell in row {
                     match cell {
-                        DataType::Empty => print!("(empty)\t"),
-                        DataType::String(s) => print!("{}\t", s),
-                        DataType::Float(f) => print!("{}\t", f),
-                        DataType::Int(i) => print!("{}\t", i),
-                        DataType::Bool(b) => print!("{}\t", b),
-                        DataType::Error(e) => print!("Error({:?})\t", e),
-                        DataType::DateTime(dt) => print!("DateTime({})\t", dt),
+                        Data::Empty => print!("(empty)\t"),
+                        Data::String(s) => print!("{}\t", s),
+                        Data::Float(f) => print!("{}\t", f),
+                        Data::Int(i) => print!("{}\t", i),
+                        Data::Bool(b) => print!("{}\t", b),
+                        Data::Error(e) => print!("Error({:?})\t", e),
+                        Data::DateTime(dt) => print!("DateTime({})\t", dt),
                         _ => print!("(unknown)\t"),
                     }
                 }

--- a/cat_xlsx/src/main.rs
+++ b/cat_xlsx/src/main.rs
@@ -20,8 +20,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let path = args.xlsx_file;
     // Check if the file exists
     if !path.exists() {
+        eprintln!("Error: File not found");
+        std::process::exit(1);
+    }
     // Validate file extension
-    if !path.extension().map_or(false, |ext| ext.eq_ignore_ascii_case("xlsx")) {
+    if !path
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("xlsx"))
+    {
         eprintln!("Error: File must have .xlsx extension");
         std::process::exit(1);
     }


### PR DESCRIPTION
- Add cat_xlsx command to the CLI tool
- Display usage information for cat_xlsx command
- Implement options for cat_xlsx command: `-h, --help` and `-V, --version`
- Update dependencies in Cargo.toml: `clap` to version 4.1 with `derive` feature, and `calamine` to version 0.26.1
- Refactor main.rs to use clap for command-line argument parsing
- Implement Args struct with xlsx_file field for parsing command-line arguments
- Check if the provided xlsx file exists before processing
- Improve error handling in main function
- Iterate over worksheets and print cells' data in cat_xlsx command