### PR TITLE
chore(pre-commit): update typos hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.26.0
+    rev: v1.28.1
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.28.1
+    rev: v1
     hooks:
       - id: typos


### PR DESCRIPTION
 - Updated the version of the typos hook from v1.28.1 to v1.
 - This change simplifies the versioning to the latest release.
 - Ensures that we are using the most recent features and fixes available.